### PR TITLE
Force the spec from server side

### DIFF
--- a/lua/ulx/modules/sh/ttt_admin.lua
+++ b/lua/ulx/modules/sh/ttt_admin.lua
@@ -582,6 +582,9 @@ function ulx.tttspec( calling_ply, target_plys, should_unspec )
 			if should_unspec then
 			    v:ConCommand("ttt_spectator_mode 0")
 			else
+			    v:Kill()
+			    v:SetForceSpec(true)
+			    v:SetTeam(TEAM_SPEC)
 			    v:ConCommand("ttt_spectator_mode 1")
 			    v:ConCommand("ttt_cl_idlepopup")
 			end


### PR DESCRIPTION
Sometimes you will notice some players aren't moved to the spectator after running the command `fspec`.

I figured out one possible reason like the game isn't active (minimized) or similar, so it doesn't receive all stuff from the server.

To prevent this issue you need to change the team and kill the player server-side.
